### PR TITLE
Make client.channel public

### DIFF
--- a/lib/twitch/bot/client.rb
+++ b/lib/twitch/bot/client.rb
@@ -19,7 +19,7 @@ module Twitch
       USER_MESSAGES_COUNT = 20
       TWITCH_PERIOD = 30.0
 
-      attr_reader :connection
+      attr_reader :connection, :channel
 
       def initialize(
         connection:, channel: nil, &block
@@ -95,7 +95,7 @@ module Twitch
       private
 
       attr_reader :adapter, :event_handlers, :event_loop_running,
-                  :input_thread, :output_thread, :channel, :messages_queue
+                  :input_thread, :output_thread, :messages_queue
 
       def create_adapter
         adapter_class = if development_mode?

--- a/lib/twitch/bot/version.rb
+++ b/lib/twitch/bot/version.rb
@@ -2,6 +2,6 @@
 
 module Twitch
   module Bot
-    VERSION = "2.1.1"
+    VERSION = "2.2.0"
   end
 end

--- a/spec/twitch/bot/client_spec.rb
+++ b/spec/twitch/bot/client_spec.rb
@@ -3,9 +3,13 @@
 RSpec.describe Twitch::Bot::Client do
   let!(:client) do
     connection = Twitch::Bot::Connection.new(
-      nickname: "test", password: "test",
+      nickname: "testuser",
+      password: "test",
     )
-    described_class.new(connection: connection)
+    described_class.new(
+      connection: connection,
+      channel: "testchannel",
+    )
   end
 
   describe "#trigger" do
@@ -47,6 +51,14 @@ RSpec.describe Twitch::Bot::Client do
       client.dispatch(message)
 
       expect(client).to have_received(:remove_moderator)
+    end
+  end
+
+  describe "#channel" do
+    it "returns the channel object" do
+      channel = client.channel
+
+      expect(channel.name).to eq "testchannel"
     end
   end
 end


### PR DESCRIPTION
This will be useful for event handlers because it'll let them access the channel name, for example.

Resolves #14