### PR TITLE
Run dev mode for channel owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog Twitch::Bot
 
+## v3.2.1
+
+* [FIXED] The Terminal adapter now returns all messages from the channel owner, allowing to test privileged functionality in dev mode.
+
 ## v3.2.0
 
 * [NEW] This release introduces a `Memory::Redis` class that allows users to provide their bot with a persistent memory storage.

--- a/lib/twitch/bot/adapter/terminal.rb
+++ b/lib/twitch/bot/adapter/terminal.rb
@@ -5,7 +5,9 @@ module Twitch
     module Adapter
       # This adapter connects the chat client to the terminal
       class Terminal
-        def initialize(client:); end
+        def initialize(client:)
+          @client = client
+        end
 
         def connect; end
 
@@ -33,11 +35,15 @@ module Twitch
 
         def read_message_from_terminal
           Twitch::Bot::Logger.debug "Waiting for input..."
-          input = gets
+          input = read_terminal
           Twitch::Bot::Message::UserMessage.new(
             text: input,
-            user: "tester",
+            user: client.channel.name,
           )
+        end
+
+        def read_terminal
+          gets
         end
       end
     end

--- a/lib/twitch/bot/version.rb
+++ b/lib/twitch/bot/version.rb
@@ -2,6 +2,6 @@
 
 module Twitch
   module Bot
-    VERSION = "3.2.0"
+    VERSION = "3.2.1"
   end
 end

--- a/spec/twitch/bot/adapter/terminal_spec.rb
+++ b/spec/twitch/bot/adapter/terminal_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe Twitch::Bot::Adapter::Terminal do
+  describe "#receive_message" do
+    it "receives all messages from channel owner" do
+      config = Twitch::Bot::Config.new(
+        settings: {
+          bot_user: "testuser",
+          adapter: "Twitch::Bot::Adapter::Terminal",
+        },
+      )
+      client = Twitch::Bot::Client.new(
+        config: config,
+        channel: "testchannel",
+      )
+      adapter = described_class.new(client: client)
+      allow(adapter).to receive(:read_terminal).and_return("Hello")
+
+      message = adapter.read_data
+
+      expect(message.user).to eq client.channel.name
+    end
+  end
+end


### PR DESCRIPTION
The `Terminal` adapter now returns all messages from the channel owner, allowing to test privileged functionality in dev mode.

Fixes #22 